### PR TITLE
v0.1.3: Ruby 3.4 compatibility + dependency updates

### DIFF
--- a/.depfu.yml
+++ b/.depfu.yml
@@ -1,0 +1,2 @@
+version: 1
+update_schedule: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Ruby
 on:
   push:
     branches:
-      - master
+      - main
 
   pull_request:
 
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.3.5'
+          - '3.4'
 
     steps:
     - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   SuggestExtensions: false
   NewCops: disable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.4
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -7,16 +7,17 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-gem "pry-byebug", "~> 3.9"
+gem "pry-byebug", "~> 3.10"
 
-gem "rubocop", "~> 1.21"
+gem "rubocop", "~> 1.71"
 
 group :development do
+  gem "brakeman"
   gem "dotenv"
 end
 
 group :test do
-  gem "minitest", "~> 5.16"
+  gem "minitest", "~> 6.0"
   gem "minitest-reporters", "~> 1.7"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,98 +1,121 @@
 PATH
   remote: .
   specs:
-    ruberto (0.1.2)
+    ruberto (0.1.3)
       faraday (~> 2.0)
       faraday-net_http_persistent
+      ostruct
+      pstore
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    ansi (1.5.0)
-    ast (2.4.2)
-    base64 (0.2.0)
-    bigdecimal (3.1.9)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    ansi (1.6.0)
+    ast (2.4.3)
+    bigdecimal (4.1.2)
+    brakeman (8.0.4)
+      racc
     builder (3.3.0)
-    byebug (11.1.3)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
     coderay (1.1.3)
-    connection_pool (2.5.0)
-    crack (1.0.0)
+    connection_pool (3.0.2)
+    crack (1.0.1)
       bigdecimal
       rexml
-    dotenv (3.1.7)
-    faraday (2.7.12)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (2.1.0)
-    faraday-net_http_persistent (2.0.2)
-      faraday-net_http (< 3)
-      net-http-persistent (~> 4.0)
-    hashdiff (1.1.2)
-    json (2.9.1)
-    language_server-protocol (3.17.0.4)
+    dotenv (3.2.0)
+    drb (2.2.3)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    faraday-net_http_persistent (2.3.1)
+      faraday (~> 2.5)
+      net-http-persistent (>= 4.0.4, < 5)
+    hashdiff (1.2.1)
+    io-console (0.8.2)
+    json (2.19.4)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
     method_source (1.1.0)
-    minitest (5.25.4)
-    minitest-reporters (1.7.1)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-reporters (1.8.0)
       ansi
       builder
-      minitest (>= 5.0)
+      minitest (>= 5.0, < 7)
       ruby-progressbar
-    net-http-persistent (4.0.5)
-      connection_pool (~> 2.2)
-    parallel (1.26.3)
-    parser (3.3.7.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
+    ostruct (0.6.3)
+    parallel (2.0.1)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pry (0.14.2)
+    prism (1.9.0)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
-    public_suffix (6.0.1)
+      reline (>= 0.6.0)
+    pry-byebug (3.12.0)
+      byebug (~> 13.0)
+      pry (>= 0.13, < 0.17)
+    pstore (0.2.1)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
-    regexp_parser (2.10.0)
-    rexml (3.4.0)
-    rubocop (1.71.0)
+    rake (13.4.2)
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rubocop (1.86.1)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
-      parallel (~> 1.10)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.36.2, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.0)
-      parser (>= 3.3.1.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
-    webmock (3.25.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin
   ruby
   x86_64-linux
 
 DEPENDENCIES
+  brakeman
   dotenv
-  minitest (~> 5.16)
+  minitest (~> 6.0)
   minitest-reporters (~> 1.7)
-  pry-byebug (~> 3.9)
+  pry-byebug (~> 3.10)
   rake (~> 13.0)
   ruberto!
-  rubocop (~> 1.21)
+  rubocop (~> 1.71)
   webmock
 
 BUNDLED WITH
-   2.5.22
+  4.0.10

--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,10 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-require "brakeman"
-
 namespace :brakeman do
   desc "Run Brakeman security scanner"
   task :check do
+    require "brakeman"
     Brakeman.run(app_path: ".", print_report: true, quiet: true)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,13 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
+require "brakeman"
+
+namespace :brakeman do
+  desc "Run Brakeman security scanner"
+  task :check do
+    Brakeman.run(app_path: ".", print_report: true, quiet: true)
+  end
+end
+
 task default: %i[test rubocop]

--- a/lib/ruberto/configuration/file_cache.rb
+++ b/lib/ruberto/configuration/file_cache.rb
@@ -7,6 +7,7 @@ module Ruberto
     def initialize(file_cache_path)
       @file_cache_path = file_cache_path
       @store = PStore.new(file_cache_path)
+      reset_if_incompatible!
     end
 
     def read(key) = @store.transaction { @store[key] }
@@ -17,5 +18,14 @@ module Ruberto
     end
 
     def delete(key) = @store.transaction { @store.delete(key) }
+
+    private
+
+    def reset_if_incompatible!
+      @store.transaction(true) { }
+    rescue StandardError
+      clear
+      @store = PStore.new(@file_cache_path)
+    end
   end
 end

--- a/lib/ruberto/configuration/file_cache.rb
+++ b/lib/ruberto/configuration/file_cache.rb
@@ -22,7 +22,7 @@ module Ruberto
     private
 
     def reset_if_incompatible!
-      @store.transaction(true) { }
+      @store.transaction(true) {}
     rescue StandardError
       clear
       @store = PStore.new(@file_cache_path)

--- a/lib/ruberto/configuration/file_cache.rb
+++ b/lib/ruberto/configuration/file_cache.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "yaml/store"
+require "pstore"
 
 module Ruberto
   class FileCache
     def initialize(file_cache_path)
       @file_cache_path = file_cache_path
-      @store = YAML::Store.new(file_cache_path)
+      @store = PStore.new(file_cache_path)
     end
 
     def read(key) = @store.transaction { @store[key] }

--- a/lib/ruberto/version.rb
+++ b/lib/ruberto/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ruberto
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/ruberto.gemspec
+++ b/ruberto.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Ruby bindings for Uber's API"
   spec.homepage = "https://github.com/unagisoftware/ruberto"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.4"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/unagisoftware/ruberto"
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "faraday-net_http_persistent"
+  spec.add_dependency "ostruct"
+  spec.add_dependency "pstore"
 end

--- a/test/ruberto/configuration/file_cache_test.rb
+++ b/test/ruberto/configuration/file_cache_test.rb
@@ -52,5 +52,19 @@ module Ruberto
       assert "value2", @cache.read("key1")
       assert_nil @cache.read("key2")
     end
+
+    def test_migrates_from_yaml_store_format
+      yaml_path = "ruberto_legacy_cache.yaml"
+      legacy = YAML::Store.new(yaml_path)
+      legacy.transaction { legacy["token"] = "old_value" }
+
+      cache = FileCache.new(yaml_path)
+
+      assert_nil cache.read("token")
+      cache.write("token", "new_value")
+      assert_equal "new_value", cache.read("token")
+    ensure
+      File.delete(yaml_path) if File.exist?(yaml_path)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Ruby 3.4**: `required_ruby_version >= 3.4`, `TargetRubyVersion 3.4` in RuboCop
- **`ostruct` and `pstore` as explicit runtime deps**: both are no longer bundled by default in Ruby 3.5+
- **`FileCache`: `YAML::Store` → `PStore`**: `Psych.safe_load` in Ruby 3.4 disallows deserializing `Time` objects without explicit permission; `PStore` uses Marshal and avoids the issue entirely
- **brakeman**: added to dev group with a `brakeman:check` Rake task
- **depfu**: added `.depfu.yml` for weekly automated dependency PRs
- **Updated constraints**: `rubocop ~> 1.71`, `pry-byebug ~> 3.10`, `minitest ~> 6.0`
- **CI**: fixed branch trigger `master` → `main`, updated to Ruby `3.4`, added `arm64-darwin` platform to lockfile

## Test plan

- [ ] All 29 tests pass with Ruby 3.4
- [ ] RuboCop reports no offenses
- [ ] `bundle exec rake brakeman:check` runs without errors